### PR TITLE
Update project's target to 2022

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "importHelpers": true,
-    "target": "ES2021",
+    "target": "ES2022",
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2020", "dom"],
     "resolveJsonModule": true


### PR DESCRIPTION
Fix warning when starting the application: `TypeScript compiler options "target" and "useDefineForClassFields" are set to "ES2022" and "false" respectively by the Angular CLI. To control ECMA version and features use the Browerslist configuration. For more information, see https://angular.io/guide/build#configuring-browser-compatibility`